### PR TITLE
Remove unnecessary dependency (hiredis) that would not build

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dotenv": "^1.2.0",
     "express": "^4.13.1",
     "express-session": "^1.17.0",
-    "hiredis": "^0.4.0",
     "ioredis": "^4.14.1",
     "morgan": "^1.6.1",
     "passport": "^0.2.2",


### PR DESCRIPTION
The `hiredis` dependency wouldn't build on my ec2 instance, and I couldn't find any mentions of it in the codebase from a quick grep, so I removed it. The application seems to work exactly the same, so I figured it's just a leftover from experimenting with different redis clients.